### PR TITLE
Browse images lightbox + route persistence + conditional PR deploys

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -6,8 +6,38 @@ on:
       - main
 
 jobs:
+  detect-changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      api_changed: ${{ steps.filter.outputs.api }}
+      website_changed: ${{ steps.filter.outputs.website }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Detect changes
+      id: filter
+      uses: dorny/paths-filter@v3
+      with:
+        filters: |
+          api:
+            - 'images-api/**'
+            - '.github/workflows/deploy-cdk-api.yml'
+            - '.github/workflows/pr-check.yml'
+            - 'package.json'
+            - 'package-lock.json'
+          website:
+            - 'website/**'
+            - '.github/workflows/deploy-website.yml'
+            - '.github/workflows/pr-check.yml'
+            - 'package.json'
+            - 'package-lock.json'
+
   test-cdk-api:
     name: Test Project
+    needs: ['detect-changes']
+    if: ${{ needs.detect-changes.outputs.api_changed == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -28,14 +58,16 @@ jobs:
   deploy-cdk-api:
     name: Deploy API via CDK
     needs: ['test-cdk-api']
+    if: ${{ needs.test-cdk-api.result == 'success' }}
     uses: ./.github/workflows/deploy-cdk-api.yml
     secrets: inherit
     with:
       account: connected-web-dev
-      
+
   post-deployment-tests:
     name: Post-deployment Tests for API
     needs: ['deploy-cdk-api']
+    if: ${{ needs.deploy-cdk-api.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -63,3 +95,10 @@ jobs:
           POST_DEPLOYMENT_AUTH_URL: ${{ vars.POST_DEPLOYMENT_AUTH_URL }}
           POST_DEPLOYMENT_CLIENT_ID: ${{ secrets.POST_DEPLOYMENT_CLIENT_ID }}
           POST_DEPLOYMENT_CLIENT_SECRET: ${{ secrets.POST_DEPLOYMENT_CLIENT_SECRET }}
+
+  deploy-website:
+    name: Deploy Website
+    needs: ['detect-changes']
+    if: ${{ needs.detect-changes.outputs.website_changed == 'true' }}
+    uses: ./.github/workflows/deploy-website.yml
+    secrets: inherit

--- a/website/src/pages/components/ImageBrowser.vue
+++ b/website/src/pages/components/ImageBrowser.vue
@@ -98,13 +98,16 @@ export default {
     viewerOpen(value: boolean) {
       if (value) {
         document.body.style.overflow = 'hidden'
+        window.addEventListener('keydown', this.onViewerKeydown)
         return
       }
       document.body.style.overflow = ''
+      window.removeEventListener('keydown', this.onViewerKeydown)
     }
   },
   unmounted() {
     document.body.style.overflow = ''
+    window.removeEventListener('keydown', this.onViewerKeydown)
   },
   methods: {
     imageWidth(resultsItem: Partial<ImageResults>, unit = 'px') {
@@ -143,6 +146,23 @@ export default {
       const count = this.resultsItem?.generatedFiles?.length ?? 0
       if (count === 0) return
       this.currentIndex = (this.currentIndex + 1) % count
+    },
+    onViewerKeydown(event: KeyboardEvent) {
+      if (!this.viewerOpen) return
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        this.closeViewer()
+        return
+      }
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault()
+        this.showPrevious()
+        return
+      }
+      if (event.key === 'ArrowRight') {
+        event.preventDefault()
+        this.showNext()
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace thumbnail click behavior with a fullscreen single-image lightbox on Browse Images.
- Add zoned controls: top to close, left for previous, right for next.
- Keep the image contained in fullscreen, hide gallery behind viewer, and lock background scroll while open.
- Replace text hints with plain icons and add background blur under the overlay tint.
- Add keyboard controls for lightbox navigation: Esc, ArrowLeft, ArrowRight.
- Persist lightbox state in URL query (`lightbox=1`, `image=<index>`) so refresh restores the same view.
- Update PR workflow to conditionally run deploy/test jobs based on changed paths:
  - API deploy and post-deploy tests only when API-related files change.
  - Website deploy only when website-related files change.

## Validation
- `npm --prefix website run build`

## Risks
- PR checks now intentionally skip unrelated deploy/test jobs when no matching paths changed; path filters should be reviewed if workflow scope changes in future.